### PR TITLE
feat: Use user ID 1000 after compiling and copying

### DIFF
--- a/ringracers-ds/Dockerfile
+++ b/ringracers-ds/Dockerfile
@@ -34,6 +34,11 @@ COPY --from=builder /ringracers-source/build/ninja-release/bin/ringracers_v$VERS
 # Copy startup script
 COPY ./startserver.sh /ringracers/startserver.sh
 
+# Changes to user id 1000 to prevent container pivoting by being root user 
+RUN chown -R 1000:1000 /ringracers
+
+USER 1000
+
 EXPOSE 5029/udp
 
 STOPSIGNAL SIGINT


### PR DESCRIPTION
# Changes
- Gives `/ringracers` folder priviledges to user id 1000
- Changes to user id 1000

This is made with the idea that, from that point forward, the container will be executed with normal user id 1000 priviledges, and not root, therefore preventing container [pivoting attacks](https://medium.com/@Kfir-G/securing-docker-non-root-user-best-practices-5784ac25e755) while the container is being executed.